### PR TITLE
Updated docs for concurrency job property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ This action is useful when the version **can not** be automatically bumped after
   with:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-It's recommend to use this action with [`styfle/cancel-workflow-action@0.10.0`](https://github.com/marketplace/actions/cancel-workflow-action) to cancel previous running actions in order to avoid confliciting actions
+It's recommended to specify the [`concurrency`](https://docs.github.com/en/actions/using-jobs/using-concurrency) property to cancel previously invoked actions in order to avoid conflicting changes.
 
 #### Full example
 ```yaml
-name: 'Bump Version'
+name: PR Version Bump
 on:
   pull_request_target:
     types:
@@ -40,15 +40,14 @@ on:
       - reopened
 
 jobs:
-  test:
+  version_bump:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: 'actions/checkout@v3'
-      - name: Pull Request Version Bump
+      - uses: actions/checkout@v3
+      - name: Bump version
         uses: fadi-quader-mox/pr-version-bump@v1.0.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Bump version
         uses: fadi-quader-mox/pr-version-bump@v1.0.0
         with:


### PR DESCRIPTION
https://github.com/marketplace/actions/cancel-workflow-action announced that it is unnecessary to use it in most cases and can simply be replaced with the job property `concurrency`.

This PR updates the docs and example accordingly.